### PR TITLE
Avoid creating when the output file exists

### DIFF
--- a/interchange_regression_utilities/commands/create_openmm_systems.py
+++ b/interchange_regression_utilities/commands/create_openmm_systems.py
@@ -52,6 +52,9 @@ def _save_openmm_system(
 
         exception = None
 
+        if Path(output_path).is_file():
+            continue
+
         try:
             create_openmm_system(
                 topology_definition,


### PR DESCRIPTION
This might help with running in preemptable queues.